### PR TITLE
fix: carregando as variaveis de ambiente do arquivo dotenv

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,11 +4,14 @@ Interface web Streamlit para o sistema RAG
 
 import streamlit as st
 import os
+from dotenv import load_dotenv
 import tempfile
 from pathlib import Path
 import logging
 from typing import List, Dict, Any
 from datetime import datetime
+
+load_dotenv()
 
 from llm_providers import LLMProviderManager
 from privacy_system import privacy_manager


### PR DESCRIPTION
As variáveis de ambiente não estavam sendo carregadas anteriormente. Por isso estava dificultando a instalação da aplicação em outras máquinas. Carreguei as variáveis do .env com a função load_dotenv da biblioteca dotenv

## Resumo por Sourcery

Carrega variáveis de ambiente de um arquivo .env na inicialização da aplicação usando `load_dotenv` do python-dotenv.

Correções de bugs:
- Garante que as variáveis de ambiente sejam carregadas de .env antes da inicialização do aplicativo.

Melhorias:
- Adiciona a dependência python-dotenv e a chamada para `load_dotenv` em app.py.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Load environment variables from a .env file at application startup using python-dotenv’s load_dotenv.

Bug Fixes:
- Ensure environment variables are loaded from .env before app initialization.

Enhancements:
- Add python-dotenv dependency and call to load_dotenv in app.py.

</details>